### PR TITLE
Resume from last seen second

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,30 +17,26 @@ jobs:
         run: |
           cmake -B ${{ github.workspace }}/coverage -DENABLE_COVERAGE=ON
           cmake --build ${{ github.workspace }}/coverage --target coverage
-          cp -r ${{ github.workspace }}/coverage/coverage coverage
 
       - name: Archive code coverage report
         uses: actions/upload-artifact@v3
         with:
           name: code-coverage-report
           path: |
-            coverage
+            ${{ github.workspace }}/coverage/coverage
 
       - name: Production binaries
         run: |
           cmake -B ${{ github.workspace }}/build -DENABLE_TESTS=OFF
           cmake --build ${{ github.workspace }}/build --target 6_player_clock
-          mkdir build
-          cp ${{ github.workspace }}/build/*.elf \
-            ${{ github.workspace }}/build/*.uf2 build
 
       - name: Archive production binaries
         uses: actions/upload-artifact@v3
         with:
           name: production-binaries
           path: |
-            build/*.elf
-            build/*.uf2
+            ${{ github.workspace }}/build/*.elf
+            ${{ github.workspace }}/build/*.uf2
 
       - name: Code documentation
         run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,26 +17,30 @@ jobs:
         run: |
           cmake -B ${{ github.workspace }}/coverage -DENABLE_COVERAGE=ON
           cmake --build ${{ github.workspace }}/coverage --target coverage
+          cp -r ${{ github.workspace }}/coverage/coverage coverage
 
       - name: Archive code coverage report
         uses: actions/upload-artifact@v3
         with:
           name: code-coverage-report
           path: |
-            ${{ github.workspace }}/coverage/coverage
+            coverage
 
       - name: Production binaries
         run: |
           cmake -B ${{ github.workspace }}/build -DENABLE_TESTS=OFF
           cmake --build ${{ github.workspace }}/build --target 6_player_clock
+          mkdir build
+          cp ${{ github.workspace }}/build/*.elf \
+            ${{ github.workspace }}/build/*.uf2 build
 
       - name: Archive production binaries
         uses: actions/upload-artifact@v3
         with:
           name: production-binaries
           path: |
-            ${{ github.workspace }}/build/*.elf
-            ${{ github.workspace }}/build/*.uf2
+            build/*.elf
+            build/*.uf2
 
       - name: Code documentation
         run: |

--- a/src/6_player_clock.cc
+++ b/src/6_player_clock.cc
@@ -22,7 +22,7 @@ int main() {
   Buzzer buzzer{buzzer::kBuzzerPin};
   Display display;
   Clock clock{&buzzer, &display};
-  ContextSwitcher context_switcher{&led, &clock, 1000};
+  ContextSwitcher context_switcher{&led, &clock, 30};
   button_controller.button_event_handler(&context_switcher);
 
   while (true) {

--- a/src/clock/clock.cc
+++ b/src/clock/clock.cc
@@ -15,9 +15,10 @@
 
 bool Clock::RepeatingTimerCallback(repeating_timer_t* repeating_timer) {
   Clock* clock = static_cast<Clock*>(repeating_timer->user_data);
+  --(clock->remaining_seconds_);
   clock->display_->ShowAsMinutesAndSeconds(clock->remaining_seconds_);
 
-  return --(clock->remaining_seconds_) >= 0;
+  return clock->remaining_seconds_ >= 0;
 }
 
 Clock::Clock(Buzzer* buzzer, Display* display): buzzer_(buzzer), display_(display), remaining_seconds_(0) {}
@@ -27,7 +28,7 @@ bool Clock::Resume(std::uint16_t remaining_seconds) {
 
   if (remaining_seconds_ > 0) {
     buzzer_->Beep();
-    // TODO(jisbert): Show remaining seconds in display.
+    display_->ShowAsMinutesAndSeconds(remaining_seconds_);
 
     return add_repeating_timer_ms(
       clock_clock::k1SecondDelayInMs,

--- a/src/clock/clock.cc
+++ b/src/clock/clock.cc
@@ -27,6 +27,7 @@ bool Clock::Resume(std::uint16_t remaining_seconds) {
 
   if (remaining_seconds_ > 0) {
     buzzer_->Beep();
+    // TODO(jisbert): Show remaining seconds in display.
 
     return add_repeating_timer_ms(
       clock_clock::k1SecondDelayInMs,

--- a/src/clock/clock.cc
+++ b/src/clock/clock.cc
@@ -37,6 +37,7 @@ bool Clock::Resume(std::uint16_t remaining_seconds) {
       &repeating_timer_);
   } else {
     buzzer_->Beep(2);
+    display_->ShowAsMinutesAndSeconds(0);
 
     return false;
   }

--- a/tests/mocks/include/buzzer/buzzer_mock.h
+++ b/tests/mocks/include/buzzer/buzzer_mock.h
@@ -12,6 +12,7 @@ class BuzzerMock : public Buzzer {
  public:  // editorconfig-checker-disable-line
   BuzzerMock();
   void Beep() final;
+  void Beep(std::uint16_t number_of_beeps) final;
 };
 
 #endif  // BUZZER_BUZZER_MOCK_H_

--- a/tests/mocks/src/buzzer/buzzer_mock.cc
+++ b/tests/mocks/src/buzzer/buzzer_mock.cc
@@ -12,3 +12,7 @@ BuzzerMock::BuzzerMock() : Buzzer(buzzer::kBuzzerPin) {}
 void BuzzerMock::Beep() {
   mock("buzzer").actualCall("Beep");
 }
+
+void BuzzerMock::Beep(std::uint16_t number_of_beeps) {
+  mock("buzzer").actualCall("Beep").withParameter("number_of_beeps", number_of_beeps);
+}

--- a/tests/src/clock/clock_tests.cc
+++ b/tests/src/clock/clock_tests.cc
@@ -46,9 +46,12 @@ TEST(Clock, Resume) {
   */
 TEST(Clock, ResumeShowsLastSeenTime) {
   mock("buzzer").expectOneCall("Beep");
-  mock("display").expectOneCall("ShowAsMinutesAndSeconds").withParameter("seconds", clock_mock::kRemainingSeconds);
-  mock("repeating_timer").expectOneCall("add_repeating_timer_ms").withParameter("delay_ms", clock_clock::k1SecondDelayInMs);
-  mock("display").expectOneCall("ShowAsMinutesAndSeconds").withParameter("seconds", clock_mock::kRemainingSeconds - 1);
+  mock("display").expectOneCall("ShowAsMinutesAndSeconds")
+    .withParameter("seconds", clock_mock::kRemainingSeconds);
+  mock("repeating_timer").expectOneCall("add_repeating_timer_ms")
+    .withParameter("delay_ms", clock_clock::k1SecondDelayInMs);
+  mock("display").expectOneCall("ShowAsMinutesAndSeconds")
+    .withParameter("seconds", clock_mock::kRemainingSeconds - 1);
   clock_->Resume(clock_mock::kRemainingSeconds);
 }
 

--- a/tests/src/clock/clock_tests.cc
+++ b/tests/src/clock/clock_tests.cc
@@ -38,8 +38,7 @@ TEST(Clock, Resume) {
   mock("buzzer").expectOneCall("Beep");
   mock("repeating_timer").expectOneCall("add_repeating_timer_ms")
     .withParameter("delay_ms", clock_clock::k1SecondDelayInMs);
-  mock("display").expectOneCall("ShowAsMinutesAndSeconds")
-    .withParameter("seconds", clock_mock::kRemainingSeconds);
+  mock("display").ignoreOtherCalls();
   clock_->Resume(clock_mock::kRemainingSeconds);
 }
 

--- a/tests/src/clock/clock_tests.cc
+++ b/tests/src/clock/clock_tests.cc
@@ -46,11 +46,17 @@ TEST(Clock, Resume) {
   */
 TEST(Clock, ResumeShowsLastSeenTime) {
   mock("buzzer").expectOneCall("Beep");
-  mock("display").expectOneCall("ShowAsMinutesAndSeconds")
-    .withParameter("seconds", clock_mock::kRemainingSeconds);
-  mock("repeating_timer").expectOneCall("add_repeating_timer_ms")
-    .withParameter("delay_ms", clock_clock::k1SecondDelayInMs);
-  mock("display").expectOneCall("ShowAsMinutesAndSeconds")
-    .withParameter("seconds", clock_mock::kRemainingSeconds - 1);
+  mock("display").expectOneCall("ShowAsMinutesAndSeconds").withParameter("seconds", clock_mock::kRemainingSeconds);
+  mock("repeating_timer").expectOneCall("add_repeating_timer_ms").withParameter("delay_ms", clock_clock::k1SecondDelayInMs);
+  mock("display").expectOneCall("ShowAsMinutesAndSeconds").withParameter("seconds", clock_mock::kRemainingSeconds - 1);
   clock_->Resume(clock_mock::kRemainingSeconds);
+}
+
+/** Test that zero is displayed when there are no remaining seconds.
+  */
+TEST(Clock, ResumeShowsZeroWhenNoRemainingSeconds) {
+  mock("buzzer").expectOneCall("Beep").withParameter("number_of_beeps", 2);
+  mock("display").expectOneCall("ShowAsMinutesAndSeconds").withParameter("seconds", 0);
+  mock("repeating_timer").ignoreOtherCalls();
+  clock_->Resume(0);
 }

--- a/tests/src/clock/clock_tests.cc
+++ b/tests/src/clock/clock_tests.cc
@@ -47,9 +47,11 @@ TEST(Clock, Resume) {
   */
 TEST(Clock, ResumeShowsLastSeenTime) {
   mock("buzzer").expectOneCall("Beep");
+  mock("display").expectOneCall("ShowAsMinutesAndSeconds")
+    .withParameter("seconds", clock_mock::kRemainingSeconds);
   mock("repeating_timer").expectOneCall("add_repeating_timer_ms")
     .withParameter("delay_ms", clock_clock::k1SecondDelayInMs);
   mock("display").expectOneCall("ShowAsMinutesAndSeconds")
-    .withParameter("seconds", clock_mock::kRemainingSeconds);
+    .withParameter("seconds", clock_mock::kRemainingSeconds - 1);
   clock_->Resume(clock_mock::kRemainingSeconds);
 }

--- a/tests/src/clock/clock_tests.cc
+++ b/tests/src/clock/clock_tests.cc
@@ -42,3 +42,14 @@ TEST(Clock, Resume) {
     .withParameter("seconds", clock_mock::kRemainingSeconds);
   clock_->Resume(clock_mock::kRemainingSeconds);
 }
+
+/** Test that the clock resumes from the last seen time.
+  */
+TEST(Clock, ResumeShowsLastSeenTime) {
+  mock("buzzer").expectOneCall("Beep");
+  mock("repeating_timer").expectOneCall("add_repeating_timer_ms")
+    .withParameter("delay_ms", clock_clock::k1SecondDelayInMs);
+  mock("display").expectOneCall("ShowAsMinutesAndSeconds")
+    .withParameter("seconds", clock_mock::kRemainingSeconds);
+  clock_->Resume(clock_mock::kRemainingSeconds);
+}


### PR DESCRIPTION
## Description

Show the last seen instant at resume.

## Related Issue(s)

Closes #28 

## Changes Made

Make the display show the last seen instant after beep and before programming timer execution.

## Testing

Verify display show is invoked twice when resuming countdown: one showing last seen instant and other after the first second passed to show the remaining seconds.

## Checklist

Please check the following items before submitting this PR:

- [x] The code builds and runs without errors.
- [ ] All existing tests pass, and new tests have been added where appropriate.
- [x] The code follows the project's coding standards and style guide.
- [x] Documentation has been updated where necessary.
